### PR TITLE
Define get_nprocs for OSX

### DIFF
--- a/src/utility.c
+++ b/src/utility.c
@@ -379,6 +379,19 @@ void ShowBanner()
 #endif
     }
 
+
+#ifdef __APPLE__
+get_nprocs (void)
+{
+    int i = 0;
+    size_t s = sizeof (i);
+    if (sysctlbyname ("hw.ncpu", &i, &s, NULL, 0))
+        return 1;
+    return i;
+
+}
+#endif
+
 void GetSysInfo()
     {
 #if defined(_WIN32) || defined(_WIN64)
@@ -389,7 +402,9 @@ SYSTEM_INFO sysinfo;
 #include "cpu-features.h"
 NumCPUs = android_getCpuCount();
 #else
+#ifdef __linux__
 #include <sys/sysinfo.h>
+#endif
 NumCPUs = get_nprocs();
 #endif
 

--- a/src/utility.c
+++ b/src/utility.c
@@ -379,7 +379,6 @@ void ShowBanner()
 #endif
     }
 
-
 #ifdef __APPLE__
 get_nprocs (void)
 {


### PR DESCRIPTION
get_nprocs is not an OSX function. So we have to find the number of
cores in another way.  We then define it as get_nprocs for OSX.
